### PR TITLE
[Learning labs] Fixed Minor bug

### DIFF
--- a/pyats_ios_example.py
+++ b/pyats_ios_example.py
@@ -144,7 +144,7 @@ class common_setup(aetest.CommonSetup):
         '''
         mark the VerifyInterfaceCountTestcase for looping.
         '''
-        # ignore VIRL lxc's
+        # ignore CML terminal_server
         devices = [d for d in testbed.devices.keys() if 'terminal_server' not in d]
 
         logger.info(banner('Looping VerifyInterfaceCountTestcase'

--- a/pyats_ios_example.py
+++ b/pyats_ios_example.py
@@ -166,11 +166,12 @@ class PingTestcase(aetest.Testcase):
     @aetest.setup
     def setup(self, device, uut_link):
         destination = []
-        parsed_dict = self.parent.parameters[device].parse('show ip interface brief')
+        # To get the link interfaces ip
         for intf in uut_link.interfaces:
+            parsed_dict = self.parent.parameters[intf.device.name].\
+                          parse('show ip interface brief')
             intf_ip = parsed_dict['interface'][intf.name]['ip_address']
-            if intf_ip not in destination:
-               destination.append(intf_ip)
+            destination.append(intf_ip)
 
         # apply loop to next section
         aetest.loop.mark(self.ping, destination = destination)

--- a/pyats_ios_example.py
+++ b/pyats_ios_example.py
@@ -164,7 +164,7 @@ class PingTestcase(aetest.Testcase):
     groups = ('basic', 'looping')
 
     @aetest.setup
-    def setup(self, device, uut_link):
+    def setup(self, uut_link):
         destination = []
         # To get the link interfaces ip
         for intf in uut_link.interfaces:

--- a/pyats_ios_example.py
+++ b/pyats_ios_example.py
@@ -145,7 +145,7 @@ class common_setup(aetest.CommonSetup):
         mark the VerifyInterfaceCountTestcase for looping.
         '''
         # ignore VIRL lxc's
-        devices = [d for d in testbed.devices.keys() if 'mgmt' not in d]
+        devices = [d for d in testbed.devices.keys() if 'terminal_server' not in d]
 
         logger.info(banner('Looping VerifyInterfaceCountTestcase'
                            ' for {}'.format(devices)))
@@ -164,10 +164,13 @@ class PingTestcase(aetest.Testcase):
     groups = ('basic', 'looping')
 
     @aetest.setup
-    def setup(self, uut_link):
+    def setup(self, device, uut_link):
         destination = []
+        parsed_dict = self.parent.parameters[device].parse('show ip interface brief')
         for intf in uut_link.interfaces:
-            destination.append(str(intf.ipv4.ip))
+            intf_ip = parsed_dict['interface'][intf.name]['ip_address']
+            if intf_ip not in destination:
+               destination.append(intf_ip)
 
         # apply loop to next section
         aetest.loop.mark(self.ping, destination = destination)


### PR DESCRIPTION
## Motivation:
```
2021-12-02T12:55:48: %AETEST-INFO: +------------------------------------------------------------------------------+
2021-12-02T12:55:48: %AETEST-INFO: |            Starting subsection marking_interface_count_testcases             |
2021-12-02T12:55:48: %AETEST-INFO: +------------------------------------------------------------------------------+
2021-12-02T12:55:48: %SCRIPT-INFO: +------------------------------------------------------------------------------+
2021-12-02T12:55:48: %SCRIPT-INFO: |    Looping VerifyInterfaceCountTestcase for ['terminal_server', 'ios1', '    |
2021-12-02T12:55:48: %SCRIPT-INFO: |                                    ios2']                                    |
2021-12-02T12:55:48: %SCRIPT-INFO: +------------------------------------------------------------------------------+
2021-12-02T12:55:48: %AETEST-INFO: The result of subsection marking_interface_count_testcases is => PASSED
2021-12-02T12:55:48: %AETEST-INFO: The result of common setup is => PASSED
2021-12-02T12:55:48: %AETEST-INFO: +------------------------------------------------------------------------------+
2021-12-02T12:55:48: %AETEST-INFO: |                 Starting testcase PingTestcase[device=ios1]                  |
2021-12-02T12:55:48: %AETEST-INFO: +------------------------------------------------------------------------------+
2021-12-02T12:55:48: %AETEST-INFO: +------------------------------------------------------------------------------+
2021-12-02T12:55:48: %AETEST-INFO: |                            Starting section setup                            |
2021-12-02T12:55:48: %AETEST-INFO: +------------------------------------------------------------------------------+
2021-12-02T12:55:48: %AETEST-ERROR: Caught an exception while executing section setup:
2021-12-02T12:55:48: %AETEST-ERROR: Traceback (most recent call last):
2021-12-02T12:55:48: %AETEST-ERROR:   File "/home/developer/dummy/pyats-ios-sample/pyats_ios_example.py", line 170, in setup
2021-12-02T12:55:48: %AETEST-ERROR:     destination.append(str(intf.ipv4.ip))
2021-12-02T12:55:48: %AETEST-ERROR: AttributeError: 'NoneType' object has no attribute 'ip'
2021-12-02T12:55:48: %AETEST-INFO: The result of section setup is => ERRORED
2021-12-02T12:55:48: %AETEST-INFO: +------------------------------------------------------------------------------+
2021-12-02T12:55:48: %AETEST-INFO: |                            Starting section ping                             |
2021-12-02T12:55:48: %AETEST-INFO: +------------------------------------------------------------------------------+
2021-12-02T12:55:48: %AETEST-INFO: Blocking ping because testcase setup did not pass.
2021-12-02T12:55:48: %AETEST-INFO: The result of section ping is => BLOCKED
2021-12-02T12:55:48: %AETEST-INFO: The result of testcase PingTestcase[device=ios1] is => ERRORED
2021-12-02T12:55:48: %AETEST-INFO: +------------------------------------------------------------------------------+
2021-12-02T12:55:48: %AETEST-INFO: |                 Starting testcase PingTestcase[device=ios2]                  |
2021-12-02T12:55:48: %AETEST-INFO: +------------------------------------------------------------------------------+
2021-12-02T12:55:49: %AETEST-INFO: +------------------------------------------------------------------------------+
2021-12-02T12:55:49: %AETEST-INFO: |                            Starting section setup                            |
2021-12-02T12:55:49: %AETEST-INFO: +------------------------------------------------------------------------------+
2021-12-02T12:55:49: %AETEST-ERROR: Caught an exception while executing section setup:
2021-12-02T12:55:49: %AETEST-ERROR: Traceback (most recent call last):
2021-12-02T12:55:49: %AETEST-ERROR:   File "/home/developer/dummy/pyats-ios-sample/pyats_ios_example.py", line 170, in setup
2021-12-02T12:55:49: %AETEST-ERROR:     destination.append(str(intf.ipv4.ip))
2021-12-02T12:55:49: %AETEST-ERROR: AttributeError: 'NoneType' object has no attribute 'ip'
2021-12-02T12:55:49: %AETEST-INFO: The result of section setup is => ERRORED
2021-12-02T12:55:49: %AETEST-INFO: +------------------------------------------------------------------------------+
2021-12-02T12:55:49: %AETEST-INFO: |                            Starting section ping                             |
2021-12-02T12:55:49: %AETEST-INFO: +------------------------------------------------------------------------------+
2021-12-02T12:55:49: %AETEST-INFO: Blocking ping because testcase setup did not pass.
2021-12-02T12:55:49: %AETEST-INFO: The result of section ping is => BLOCKED
2021-12-02T12:55:49: %AETEST-INFO: The result of testcase PingTestcase[device=ios2] is => ERRORED
2021-12-02T12:55:49: %AETEST-INFO: +------------------------------------------------------------------------------+
2021-12-02T12:55:49: %AETEST-INFO: |    Starting testcase VerifyInterfaceCountTestcase[device=terminal_server]    |
2021-12-02T12:55:49: %AETEST-INFO: +------------------------------------------------------------------------------+
2021-12-02T12:55:49: %AETEST-INFO: +------------------------------------------------------------------------------+
2021-12-02T12:55:49: %AETEST-INFO: |                   Starting section extract_interface_count                   |
2021-12-02T12:55:49: %AETEST-INFO: +------------------------------------------------------------------------------+
2021-12-02T12:55:49: %AETEST-ERROR: Failed reason: Device terminal_server 'show version' failed: 'terminal_server'
2021-12-02T12:55:49: %AETEST-INFO: The result of section extract_interface_count is => FAILED
2021-12-02T12:55:49: %AETEST-INFO: +------------------------------------------------------------------------------+
2021-12-02T12:55:49: %AETEST-INFO: |                   Starting section verify_interface_count                    |
2021-12-02T12:55:49: %AETEST-INFO: +------------------------------------------------------------------------------+
2021-12-02T12:55:49: %AETEST-WARNING: Goto 'exit': aborting script run immediately.
2021-12-02T12:55:49: %AETEST-INFO: The result of section verify_interface_count is => ABORTED
2021-12-02T12:55:49: %AETEST-INFO: The result of testcase VerifyInterfaceCountTestcase[device=terminal_server] is => ABORTED
2021-12-02T12:55:49: %CONTRIB-INFO: WebEx Token not given as argument or in config. No WebEx notification will be sent
2021-12-02T12:55:49: %EASYPY-INFO: --------------------------------------------------------------------------------
2021-12-02T12:55:49: %EASYPY-INFO: Job finished. Wrapping up...
2021-12-02T12:55:49: %EASYPY-INFO: Creating archive file: /home/developer/.pyats/archive/21-Dec/pyats_ios_example_job.2021Dec02_12:55:35.446216.zip
2021-12-02T12:55:49: %EASYPY-INFO: +------------------------------------------------------------------------------+
2021-12-02T12:55:49: %EASYPY-INFO: |                                Easypy Report                                 |
2021-12-02T12:55:49: %EASYPY-INFO: +------------------------------------------------------------------------------+
2021-12-02T12:55:49: %EASYPY-INFO: pyATS Instance   : /home/developer/py3venv
2021-12-02T12:55:49: %EASYPY-INFO: Python Version   : cpython-3.6.8 (64bit)
2021-12-02T12:55:49: %EASYPY-INFO: CLI Arguments    : /home/developer/py3venv/bin/pyats run job pyats_ios_example_job.py --testbed-file default_testbed.yaml
2021-12-02T12:55:49: %EASYPY-INFO: User             : developer
2021-12-02T12:55:49: %EASYPY-INFO: Host Server      : devbox
2021-12-02T12:55:49: %EASYPY-INFO: Host OS Version  : CentOS Linux 7 Core (x86_64)
2021-12-02T12:55:49: %EASYPY-INFO:
2021-12-02T12:55:49: %EASYPY-INFO: Job Information
2021-12-02T12:55:49: %EASYPY-INFO:     Name         : pyats_ios_example_job
2021-12-02T12:55:49: %EASYPY-INFO:     Start time   : 2021-12-02 12:55:38.103295
2021-12-02T12:55:49: %EASYPY-INFO:     Stop time    : 2021-12-02 12:55:49.080772
2021-12-02T12:55:49: %EASYPY-INFO:     Elapsed time : 10.977477
2021-12-02T12:55:49: %EASYPY-INFO:     Archive      : /home/developer/.pyats/archive/21-Dec/pyats_ios_example_job.2021Dec02_12:55:35.446216.zip
2021-12-02T12:55:49: %EASYPY-INFO:
2021-12-02T12:55:49: %EASYPY-INFO: Total Tasks    : 1
2021-12-02T12:55:49: %EASYPY-INFO:
2021-12-02T12:55:49: %EASYPY-INFO: Overall Stats
2021-12-02T12:55:49: %EASYPY-INFO:     Passed     : 1
2021-12-02T12:55:49: %EASYPY-INFO:     Passx      : 0
2021-12-02T12:55:49: %EASYPY-INFO:     Failed     : 0
2021-12-02T12:55:49: %EASYPY-INFO:     Aborted    : 1
2021-12-02T12:55:49: %EASYPY-INFO:     Blocked    : 0
2021-12-02T12:55:49: %EASYPY-INFO:     Skipped    : 0
2021-12-02T12:55:49: %EASYPY-INFO:     Errored    : 2
2021-12-02T12:55:49: %EASYPY-INFO:
2021-12-02T12:55:49: %EASYPY-INFO:     TOTAL      : 4
2021-12-02T12:55:49: %EASYPY-INFO:
2021-12-02T12:55:49: %EASYPY-INFO: Success Rate   : 25.00 %
2021-12-02T12:55:49: %EASYPY-INFO:
2021-12-02T12:55:49: %EASYPY-INFO: +------------------------------------------------------------------------------+
2021-12-02T12:55:49: %EASYPY-INFO: |                             Task Result Summary                              |
2021-12-02T12:55:49: %EASYPY-INFO: +------------------------------------------------------------------------------+
2021-12-02T12:55:49: %EASYPY-INFO: Task-1: pyats_ios_example.common_setup                                    PASSED
2021-12-02T12:55:49: %EASYPY-INFO: Task-1: pyats_ios_example.PingTestcase[device=ios1]                      ERRORED
2021-12-02T12:55:49: %EASYPY-INFO: Task-1: pyats_ios_example.PingTestcase[device=ios2]                      ERRORED
2021-12-02T12:55:49: %EASYPY-INFO: Task-1: pyats_ios_example.VerifyInterfaceCountTestcase[device=termi...   ABORTED
2021-12-02T12:55:49: %EASYPY-INFO:
2021-12-02T12:55:49: %EASYPY-INFO: +------------------------------------------------------------------------------+
2021-12-02T12:55:49: %EASYPY-INFO: |                             Task Result Details                              |
2021-12-02T12:55:49: %EASYPY-INFO: +------------------------------------------------------------------------------+
2021-12-02T12:55:49: %EASYPY-INFO: Task-1: pyats_ios_example
2021-12-02T12:55:49: %EASYPY-INFO: |-- common_setup                                                          PASSED
2021-12-02T12:55:49: %EASYPY-INFO: |   |-- check_topology                                                    PASSED
2021-12-02T12:55:49: %EASYPY-INFO: |   |-- establish_connections                                             PASSED
2021-12-02T12:55:49: %EASYPY-INFO: |   |   |-- STEP 1: Connecting to Router-1                                PASSED
2021-12-02T12:55:49: %EASYPY-INFO: |   |   `-- STEP 2: Connecting to Router-2                                PASSED
2021-12-02T12:55:49: %EASYPY-INFO: |   `-- marking_interface_count_testcases                                 PASSED
2021-12-02T12:55:49: %EASYPY-INFO: |-- PingTestcase[device=ios1]                                            ERRORED
2021-12-02T12:55:49: %EASYPY-INFO: |   |-- setup                                                            ERRORED
2021-12-02T12:55:49: %EASYPY-INFO: |   `-- ping                                                             BLOCKED
2021-12-02T12:55:49: %EASYPY-INFO: |-- PingTestcase[device=ios2]                                            ERRORED
2021-12-02T12:55:49: %EASYPY-INFO: |   |-- setup                                                            ERRORED
2021-12-02T12:55:49: %EASYPY-INFO: |   `-- ping                                                             BLOCKED
2021-12-02T12:55:49: %EASYPY-INFO: `-- VerifyInterfaceCountTestcase[device=terminal_server]                 ABORTED
2021-12-02T12:55:49: %EASYPY-INFO:     |-- extract_interface_count                                           FAILED
2021-12-02T12:55:49: %EASYPY-INFO:     `-- verify_interface_count                                           ABORTED
2021-12-02T12:55:49: %EASYPY-INFO: Sending report email...
2021-12-02T12:55:49: %EASYPY-INFO: Missing SMTP server configuration, or failed to reach/authenticate/send mail. Result notification email failed to send.
2021-12-02T12:55:49: %EASYPY-INFO: Done!
```


